### PR TITLE
export default class

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Punnett Square Calculator
 **create a new class instance of PunnettSquare**
 
 ```javascript
-import { PunnettSquare } from 'punnett-square';
+import PunnettSquare from 'punnett-square';
 
 // traits should be ordered from most dominant to least
 const TRAITS = ['black', 'brown', 'blonde', 'red'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punnett-square",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A Punnett Square Calculator",
   "repository": {
     "type": "git",
@@ -26,7 +26,6 @@
     "test": "npm run lint && npm run test:mocha"
   },
   "dependencies": {
-    "babel-preset-stage-3": "6.24.1",
     "lodash": "4.17.4"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export PunnettSquare from './punnett';
+export default from './punnett';

--- a/test/src/punnett.test.js
+++ b/test/src/punnett.test.js
@@ -1,6 +1,6 @@
 import should from 'should';
 import * as _ from 'lodash';
-import { PunnettSquare } from '../../src';
+import PunnettSquare from '../../src';
 
 const TRAITS = [
   'black',


### PR DESCRIPTION
- export punnet-square class as default.
- remove unused babel plugin dependency
- fix tests
- update readme
- bump version to 2.0 to reflect breaking changes